### PR TITLE
new - okta sso support

### DIFF
--- a/passport.js
+++ b/passport.js
@@ -227,7 +227,7 @@ module.exports = function(passport) {
   
   passport.use(new SamlStrategy({
     entryPoint: config.strategies.saml.entryPoint,
-    issuer: config.strategies.saml.issuer ,
+    issuer: config.strategies.saml.issuer,
     callbackUrl: config.strategies.saml.callbackUrl,
     // TODO: confirm if the following three settings are necessary for any use-case
     // privateCert:  fs.readFileSync(onfig.strategies.saml.privateCert'./cert-scripts/azeem_com.key', 'utf-8'),
@@ -240,16 +240,31 @@ module.exports = function(passport) {
   },
   function(profile, done) {
     let claim = 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/';
-    let props = ['upn', 'name', 'emailaddress'];
+    let props = [
+      'upn', // adfs
+      'name', // adfs
+      'emailaddress', // adfs, okta
+      'nameID' // okta
+    ];
+
     let userProfile = {};
+
     props.forEach(prop => {
       let value = profile[claim + prop];
-      if(Array.isArray(value)){
+      !value && (value = profile[prop]);
+
+      if (Array.isArray(value)){
         userProfile[prop] = value[0];
       } else {
         userProfile[prop] = value;        
       }
     });
+
+    // 'firstName', 'lastName' are from okta (keys depend on okta settings)
+    profile.firstName && (
+      userProfile.name = `${profile.firstName} ${profile.lastName || ''}`
+    );
+
     return done(null, userProfile);
   }));
 


### PR DESCRIPTION
I added a test app on okta dev console named `test-ideawake-saml`. The users added to that app on okta should able to login through sso on ideawake. For this okta app we need to set env variable `"SAML_ENTRY_POINT": "https://dev-343654.oktapreview.com/home/ideawakedev343654_testideawakesaml_1/0oaeu0z3azNhsHnWA0h7/alneu1d31kvbG32Ys0h7"`