### PR TITLE
Enabled invites with oauth strategy

### DIFF
--- a/authorization.js
+++ b/authorization.js
@@ -155,15 +155,23 @@ exports.validateRefreshToken = function(req, res, next) {
 
 exports.SAMLAuthorization = function(req, res, next) {
   let Invite = mongoose.model('Invite');
-  const { invitationId } = 
-    req.body && req.body.RelayState 
-    ? JSON.parse(req.body.RelayState)
-    : {};    
+
+  // AdFS/Okta RelayState and oAuth state param to get invitationId
+  let stateInvitation = {};
+  if (req.body && req.body.RelayState) {
+    stateInvitation = JSON.parse(req.body.RelayState);
+  }
+  
+  if (req.query && req.query.state) {
+    stateInvitation = JSON.parse(req.query.state);
+  }
+  const { invitationId } = stateInvitation;
+  
   let email = (
     req.user.emailaddress || req.user.email ||
     req.user.emailAddress || req.user.upn || req.user.nameID
   ).toLowerCase();
-
+  
   User.findOneUser({ email }, true)
     .then(user => {
       if (!user) {

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -72,7 +72,7 @@ module.exports = function (MeanUser, app, circles, database, passport) {
     // Reference Link: 
     //https://stackoverflow.com/questions/24601188/how-do-i-redirect-back-to-the-originally-requested-url-after-authentication-with/46555155#46555155
     if (req.query && req.query.inv) {
-      req.query.RelayState = JSON.stringify({ invitationId: req.query.inv });
+      req.query.RelayState = JSON.stringify({ invitationId: req.query.inv });      
     }
 
     passport.authenticate('saml', {
@@ -94,9 +94,15 @@ module.exports = function (MeanUser, app, circles, database, passport) {
   
   // ============ AZURE OAUTH ENDPOINTS ===========
 
-  app.route('/api/oauth/azure').get(
-    passport.authenticate('azure-oauth')
-  );
+  app.route('/api/oauth/azure')    
+  .get(function(req, res, next) {
+    // In oauth we can use state param to keey track of invitationId
+    const params = {};
+    if (req.query && req.query.inv) {
+      params.state = JSON.stringify({ invitationId: req.query.inv });
+    }
+    passport.authenticate('azure-oauth', params)(req, res, next);
+  });
 
   app.route('/api/oauth/azure/callback').get(
     passport.authenticate('azure-oauth'),


### PR DESCRIPTION
Fixed,

1) Reload on to SSO on redeem invite page for oauth
2) Integrate invites with oauth to update invite with which user is signing up. (Used oauth `state` param)
    changes are pushed for this in `integrate-oauth-invites` branch of meanio-users
3) Fixed a translation key on add secondary email page.